### PR TITLE
Use new lizzy version format

### DIFF
--- a/lizzy_client/lizzy.py
+++ b/lizzy_client/lizzy.py
@@ -29,7 +29,7 @@ FINAL_STATES = ["CF:CREATE_COMPLETE",
                 "LIZZY:ERROR",
                 "LIZZY:REMOVED"]
 
-TARGET_VERSION = '1.4.2'
+TARGET_VERSION = '1.4'
 
 
 def make_header(access_token: str):

--- a/lizzy_client/lizzy.py
+++ b/lizzy_client/lizzy.py
@@ -29,7 +29,7 @@ FINAL_STATES = ["CF:CREATE_COMPLETE",
                 "LIZZY:ERROR",
                 "LIZZY:REMOVED"]
 
-TARGET_VERSION = '2016-02-22'
+TARGET_VERSION = '1.4.2'
 
 
 def make_header(access_token: str):

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,8 @@
 [flake8]
 max-line-length = 120
+
+[tox]
+envlist=py35
+
+[testenv]
+commands=python setup.py test


### PR DESCRIPTION
Changes:
- Use new `lizzy` unified version format.

Depends on https://github.com/zalando/lizzy/pull/60