### PR TITLE
Usability improvements: relaxed dependency versions, short "-h" and abbreviated commands

### DIFF
--- a/lizzy_client/cli.py
+++ b/lizzy_client/cli.py
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
  language governing permissions and limitations under the License.
 """
 
-from clickclick import Action, OutputFormat, print_table, info, fatal_error
+from clickclick import Action, OutputFormat, print_table, info, fatal_error, AliasedGroup
 from tokens import InvalidCredentialsError
 from typing import Optional
 import click
@@ -56,7 +56,7 @@ TITLES = {
 
 requests.packages.urllib3.disable_warnings()  # Disable the security warnings
 
-main = click.Group()
+main = AliasedGroup(context_settings=dict(help_option_names=['-h', '--help']))
 output_option = click.option('-o', '--output', type=click.Choice(['text', 'json', 'tsv']), default='text',
                              help='Use alternative output format')
 watch_option = click.option('-w', '--watch', type=click.IntRange(1, 300), metavar='SECS',
@@ -95,6 +95,7 @@ def create(definition: str, image_version: str, keep_stacks: int,
            traffic: int, verbose: bool, senza_parameters: list,
            app_version: Optional[str], stack_version: Optional[str],
            disable_rollback: bool):
+    '''Deploy a new Cloud Formation stack'''
     senza_parameters = senza_parameters or []
 
     config = Configuration()
@@ -196,6 +197,7 @@ def list_stacks(stack_ref: str, all: bool, watch: int, output: str):
 @click.argument('stack_version')
 @click.argument('percentage', type=click.IntRange(0, 100, clamp=True))
 def traffic(stack_name: str, stack_version: str, percentage: int):
+    '''Switch traffic'''
     config = Configuration()
 
     access_token = fetch_token(config.token_url, config.scopes, config.credentials_dir)
@@ -211,6 +213,7 @@ def traffic(stack_name: str, stack_version: str, percentage: int):
 @click.argument('stack_name')
 @click.argument('stack_version')
 def delete(stack_name: str, stack_version: str):
+    '''Delete a single stack'''
     config = Configuration()
 
     access_token = fetch_token(config.token_url, config.scopes, config.credentials_dir)

--- a/setup.py
+++ b/setup.py
@@ -20,19 +20,19 @@ from lizzy_client.version import VERSION
 
 requirements = [
     'click>=6.3,<7.0',
-    'clickclick==0.15',
-    'requests==2.9.1',
-    'pyyaml==3.11',
-    'python-dateutil==2.5.0',
-    'stups-tokens==1.0.17',
-    'environmental==1.0',
-    'urlpath==1.1.2',
-    'typing==3.5.0.1'
+    'clickclick>=0.15',
+    'requests>=2.9.1',
+    'pyyaml>=3.11',
+    'python-dateutil>=2.5.0',
+    'stups-tokens>=1.0.17',
+    'environmental>=1.0',
+    'urlpath>=1.1.2',
+    'typing>=3.5.0.1'
 ]
 
 test_requirements = [
-    'pytest-cov==2.2.1',
-    'pytest==2.9.0'
+    'pytest-cov>=2.2.1',
+    'pytest>=2.9.0'
 ]
 
 


### PR DESCRIPTION
* relax dependencies (require >=)
* allow short `-h` help option
* allow abbreviating all commands ("c" instead of "create" for example) --- this makes it behave similar to Senza