### PR TITLE
Do not override senza cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ setup(
     ],
     long_description='Lizzy-client',
     entry_points={'console_scripts': ['lizzy = lizzy_client.cli:main',
-                                      'senza = lizzy_client.cli:main',  # compability with senza
                                       'please = lizzy_client.cli:main',
                                       'pretty-please = lizzy_client.cli:main']},
 )


### PR DESCRIPTION
Fixes #77 

We can override the senza command in a toolchain to be used within the CI pipeline, so no need to override this in the python package level.