### PR TITLE
Do not set traffic by default

### DIFF
--- a/lizzy_client/cli.py
+++ b/lizzy_client/cli.py
@@ -168,7 +168,7 @@ def setup_lizzy_client(explicit_agent_url=None):
 @click.option('-f', '--force', is_flag=True, help='Ignore failing validation checks')
 @click.option('-t', '--tag', help='Tags to associate with the stack.', multiple=True)
 @click.option('--keep-stacks', type=int, help="Number of old stacks to keep")
-@click.option('--traffic', default=0, type=click.IntRange(0, 100, clamp=True),
+@click.option('--traffic', type=click.IntRange(0, 100, clamp=True),
               help="Percentage of traffic for the new stack")
 @click.option('--parameter-file',
               help='Config file for params',


### PR DESCRIPTION
Since the default value of the `--traffic` command line option for `lizzy create` is `0`, this means that `lizzy.traffic` will always be called, even if no `--traffic` is specified.

This PR sets the default to `None` which satisfies the conditional already present in the code.

The biggest problem with the current state of the code is that every stack creation triggers a traffic update.  Furthermore, the client does not wait for the switch to be complete, meaning that in CI/CD pipelines (we're using Jenkins) the pipeline moves onto the next stage, and if this tries to set the traffic of the newly created stack, this fails due to the stacks being in the `UPDATE_IN_PROGRESS` state.
