### PR TITLE
Only show traffic for completed stacks

### DIFF
--- a/lizzy_client/cli.py
+++ b/lizzy_client/cli.py
@@ -349,14 +349,15 @@ def traffic(stack_name: str,
         with Action('Requesting traffic info..'):
             stack_weights = []
             for stack in lizzy.get_stacks(stack_reference, region=region):
-                stack_id = '{stack_name}-{version}'.format_map(stack)
-                traffic = lizzy.get_traffic(stack_id, region=region)
-                stack_weights.append({
-                    'stack_name': stack_name,
-                    'version': stack['version'],
-                    'identifier': stack_id,
-                    'weight%': traffic['weight']
-                })
+                if stack['status'].endswith('_COMPLETE'):
+                    stack_id = '{stack_name}-{version}'.format_map(stack)
+                    traffic = lizzy.get_traffic(stack_id, region=region)
+                    stack_weights.append({
+                        'stack_name': stack_name,
+                        'version': stack['version'],
+                        'identifier': stack_id,
+                        'weight%': traffic['weight']
+                    })
         cols = 'stack_name version identifier weight%'.split()
         with OutputFormat(output):
             print_table(cols,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -396,7 +396,7 @@ def test_traffic(mock_get_token, mock_fake_lizzy):
 
     # Use traffic command to print the traffic of instances
     with patch.object(mock_fake_lizzy, 'get_stacks', return_value=[
-            {'stack_name': 'lizzy-test', 'version': 'v1'}]), patch.object(
+            {'stack_name': 'lizzy-test', 'version': 'v1', 'status': 'UPDATE_COMPLETE'}]), patch.object(
                 mock_fake_lizzy, 'get_traffic', return_value={'weight': 100}):
         runner = CliRunner()
         result = runner.invoke(main, ['traffic', 'lizzy-test'], env=FAKE_ENV,
@@ -410,7 +410,7 @@ def test_traffic(mock_get_token, mock_fake_lizzy):
 
     # Use traffic command to print the traffic of instances in a different region
     with patch.object(mock_fake_lizzy, 'get_stacks', return_value=[
-            {'stack_name': 'lizzy-test', 'version': 'v1'}]), patch.object(
+            {'stack_name': 'lizzy-test', 'version': 'v1', 'status': 'UPDATE_COMPLETE'}]), patch.object(
                 mock_fake_lizzy, 'get_traffic', return_value={'weight': 100}):
         runner = CliRunner()
         result = runner.invoke(main, ['traffic', 'lizzy-test', '--region', 'ab-bar-7'],
@@ -426,7 +426,7 @@ def test_traffic(mock_get_token, mock_fake_lizzy):
     # as a stack filter (on the Senza cli side in the agent) and
     # not as traffic change percentage.
     with patch.object(mock_fake_lizzy, 'get_stacks', return_value=[
-            {'stack_name': 'lizzy-test', 'version': 'v1'}]), patch.object(
+            {'stack_name': 'lizzy-test', 'version': 'v1', 'status': 'UPDATE_COMPLETE'}]), patch.object(
                 mock_fake_lizzy, 'get_traffic', return_value={'weight': 100}):
         runner = CliRunner()
         result = runner.invoke(main, ['traffic', 'lizzy-test', '90'], env=FAKE_ENV,


### PR DESCRIPTION
If there is any stack in state `ROLLBACK_COMPLETE` then Lizzy should not check traffic status for that stack.